### PR TITLE
Add hook for when running command `sls offline`

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ class ServerlessPlugin {
     ];
 
     this.hooks = {
+      'before:offline:start': this.startHandler.bind(this),
       'before:offline:start:init': this.startHandler.bind(this),
       'before:invoke:local:invoke': this.startHandler.bind(this),
       'before:appsync-offline:start:startHandler': this.startHandler.bind(this),


### PR DESCRIPTION
The hook `before:offline:start:init` only fires if you run sls offline start.
If you run `sls offline` the hook `before:offline:start` is fired instead.

fixes #12